### PR TITLE
Currency conversion and centering

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -272,7 +272,6 @@ function Page() {
             numSimulations={formData.numSimulations}
             totalPulls={formData.pulls + Math.floor(formData.currency / conversionRate)}
             pulls={formData.pulls}
-            currency={formData.currency}
             currencyPulls={Math.floor(formData.currency / conversionRate)}
             successRate={successRate}
             weaponCopies={formData.weaponCopies}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -109,7 +109,7 @@ function Page() {
   }
 
   return (
-    <div className="min-h-screen ">
+    <div className="min-h-screen flex items-center justify-center px-4">
       <div className="container max-w-3xl p-6 mx-auto space-y-8">
         {/* Header */}
         {/* <div className="py-8 space-y-4 text-center">
@@ -125,7 +125,7 @@ function Page() {
         </div> */}
 
         {/* Main Card */}
-        <Card className="shadow-2xl bg-slate-900/50 border-slate-700/50 backdrop-blur-xl mt-20">
+        <Card className="shadow-2xl bg-slate-900/50 border-slate-700/50 backdrop-blur-xl">
           <CardContent className="space-y-8">
             {/* Game Selection */}
             <div className="space-y-3 ">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useState } from "react";
+import {Suspense, useEffect, useState} from "react";
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -50,6 +50,7 @@ function Page() {
     currency: 0,
     weaponCopies: 0,
     weaponPity: 0,
+    conversionRate: 160,
   });
 
   function updateFormData(key: keyof ISimulatorInput, value: number | boolean) {
@@ -85,6 +86,7 @@ function Page() {
       currency: formData.currency,
       weaponCopies: formData.weaponCopies,
       weaponPity: formData.weaponPity,
+      conversionRate: formData.conversionRate
     });
     setSuccessRate(res);
 
@@ -97,11 +99,15 @@ function Page() {
     }, 100);
   }
 
+  const conversionRate = selectedGame.id === "custom"
+      ? customSimulationSettings.conversionRate
+      : selectedGame.simulationSettings.conversionRate;
+
   function validateForm() {
     return (
       (formData.pulls > 0
         ? formData.currency >= 0
-        : formData.currency >= 160) &&
+        : formData.currency >= conversionRate) &&
       formData.characterPity >= 0 &&
       formData.weaponPity >= 0 &&
       formData.numSimulations > 0 &&
@@ -261,16 +267,18 @@ function Page() {
         {successRate >= 0 && (
           <SimulationResultsCard
             characterCopies={formData.characterCopies}
+
             gameTerms={selectedGame.gameTerms}
             numSimulations={formData.numSimulations}
-            totalPulls={formData.pulls + Math.floor(formData.currency / 160)}
+            totalPulls={formData.pulls + Math.floor(formData.currency / conversionRate)}
             pulls={formData.pulls}
             currency={formData.currency}
-            currencyPulls={Math.floor(formData.currency / 160)}
+            currencyPulls={Math.floor(formData.currency / conversionRate)}
             successRate={successRate}
             weaponCopies={formData.weaponCopies}
           />
         )}
+
       </div>
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -47,6 +47,7 @@ function Page() {
     isWeaponGuaranteed: false,
     numSimulations: 10000,
     pulls: 0,
+    currency: 0,
     weaponCopies: 0,
     weaponPity: 0,
   });
@@ -81,6 +82,7 @@ function Page() {
       isWeaponGuaranteed: formData.isWeaponGuaranteed,
       numSimulations: formData.numSimulations,
       pulls: formData.pulls,
+      currency: formData.currency,
       weaponCopies: formData.weaponCopies,
       weaponPity: formData.weaponPity,
     });
@@ -97,7 +99,8 @@ function Page() {
 
   function validateForm() {
     return (
-      formData.pulls > 0 &&
+      (formData.pulls > 0 ||
+      formData.currency >= 160) &&
       formData.characterPity >= 0 &&
       formData.weaponPity >= 0 &&
       formData.numSimulations > 0 &&
@@ -192,6 +195,13 @@ function Page() {
               }
               pulls={formData.pulls}
               setPulls={(value) => updateFormData("pulls", value)}
+
+              currencyName={
+                  selectedGame.gameTerms.currencyName +
+                  selectedGame.gameTerms.currencyConjugation
+              }
+              currency={formData.currency}
+              setCurrency={(value) => updateFormData("currency", value)}
             />
 
             {/* Banner Configuration */}
@@ -252,7 +262,10 @@ function Page() {
             characterCopies={formData.characterCopies}
             gameTerms={selectedGame.gameTerms}
             numSimulations={formData.numSimulations}
+            totalPulls={formData.pulls + Math.floor(formData.currency / 160)}
             pulls={formData.pulls}
+            currency={formData.currency}
+            currencyPulls={Math.floor(formData.currency / 160)}
             successRate={successRate}
             weaponCopies={formData.weaponCopies}
           />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -99,8 +99,9 @@ function Page() {
 
   function validateForm() {
     return (
-      (formData.pulls > 0 ||
-      formData.currency >= 160) &&
+      (formData.pulls > 0
+        ? formData.currency >= 0
+        : formData.currency >= 160) &&
       formData.characterPity >= 0 &&
       formData.weaponPity >= 0 &&
       formData.numSimulations > 0 &&

--- a/src/components/CustomGameSettingsCard.tsx
+++ b/src/components/CustomGameSettingsCard.tsx
@@ -219,6 +219,20 @@ export default function CustomGameSettingsCard({
             allowDecimals
           />
         </div>
+
+        {/* Custom currency conversion */}
+        <h3 className="text-teal-300 font-semibold">Currency Conversion</h3>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <NumberInputField
+            label="Currency Conversion Rate"
+            tooltip="The conversion rate of the currency to equal a single pull"
+            value={formData.conversionRate}
+            onChange={(value) => {
+                updateFormData("conversionRate", value);
+            }}
+            className={inputClassName}
+          />
+        </div>
       </CardContent>
     </Card>
   );

--- a/src/components/SimulationResultsCard.tsx
+++ b/src/components/SimulationResultsCard.tsx
@@ -14,7 +14,6 @@ interface Props {
   successRate: number;
   totalPulls: number;
   pulls: number;
-  currency: number;
   currencyPulls: number;
   characterCopies: number;
   weaponCopies: number;

--- a/src/components/SimulationResultsCard.tsx
+++ b/src/components/SimulationResultsCard.tsx
@@ -49,7 +49,7 @@ export default function SimulationResultsCard({
           the chance you have of getting <strong>{characterCopies}</strong>{" "}
           Limited {gameTerms.characterName} and <strong>{weaponCopies}</strong>{" "}
           Limited {gameTerms.weaponName} copies with{" "}
-          <strong>{pulls.toLocaleString()}</strong> warps
+          <strong>{totalPulls.toLocaleString()}</strong> warps
         </CardDescription>
       </CardHeader>
 

--- a/src/components/SimulationResultsCard.tsx
+++ b/src/components/SimulationResultsCard.tsx
@@ -12,7 +12,10 @@ import { IGameTerms } from "@/lib/games";
 interface Props {
   numSimulations: number;
   successRate: number;
+  totalPulls: number;
   pulls: number;
+  currency: number;
+  currencyPulls: number;
   characterCopies: number;
   weaponCopies: number;
   gameTerms: IGameTerms;
@@ -21,7 +24,9 @@ interface Props {
 export default function SimulationResultsCard({
   characterCopies,
   numSimulations,
+  totalPulls,
   pulls,
+  currencyPulls,
   successRate,
   weaponCopies,
   gameTerms,
@@ -35,8 +40,10 @@ export default function SimulationResultsCard({
         </CardTitle>
         <CardDescription className="text-slate-300 leading-relaxed">
           Ran <strong>{numSimulations.toLocaleString()}</strong> simulations,
-          each consisting of <strong>{pulls.toLocaleString()}</strong>{" "}
-          {gameTerms.pullName + gameTerms.pullConjugation}. Simulations began on
+          each consisting of <strong>{totalPulls.toLocaleString()}</strong>{" "}
+          total {gameTerms.pullName + gameTerms.pullConjugation} where <strong>{pulls.toLocaleString()}</strong>{" "}
+          were from {gameTerms.pullName + gameTerms.pullConjugation} and <strong>{currencyPulls.toLocaleString()}</strong>{" "}
+          were from {gameTerms.currencyName + gameTerms.currencyConjugation}. Simulations began on
           the {gameTerms.characterName} banner and switched to the{" "}
           {gameTerms.weaponName} banner after obtaining the desired number of
           limited {gameTerms.characterName}. The result percentage represents

--- a/src/components/SimulationSettingsCard.tsx
+++ b/src/components/SimulationSettingsCard.tsx
@@ -8,6 +8,9 @@ interface Props {
   pullName: string;
   setPulls: (value: number) => void;
   pulls: number;
+  currencyName: string;
+  setCurrency: (value: number) => void;
+  currency: number;
   setNumSimulations: (value: number) => void;
   numSimulations: number;
 }
@@ -18,6 +21,9 @@ export default function SimulationSettingsCard({
   pullName,
   pulls,
   setPulls,
+  currencyName,
+  currency,
+  setCurrency
 }: Props) {
   return (
     <Card className="shadow-lg bg-gradient-to-br from-indigo-500/10 to-indigo-500/10 border-indigo-500/30">
@@ -37,6 +43,14 @@ export default function SimulationSettingsCard({
             value={pulls}
             onChange={setPulls}
             className=" border-indigo-500/30 focus:border-indigo-400"
+          />
+
+          <NumberInputField
+              label={currencyName}
+              tooltip={`Number of ${currencyName} to spend`}
+              value={currency}
+              onChange={setCurrency}
+              className=" border-indigo-500/30 focus:border-indigo-400"
           />
 
           <NumberInputField

--- a/src/lib/games.ts
+++ b/src/lib/games.ts
@@ -147,7 +147,7 @@ export const CUSTOM_GAME: IGame = {
     limitedCategory: "5★",
     pullName: "Pull",
     pullConjugation: "s",
-    currencyName: "Currenc",
+    currencyName: "Currency",
     currencyConjugation: "ies",
     characterName: "Character",
     weaponName: "Weapon",

--- a/src/lib/games.ts
+++ b/src/lib/games.ts
@@ -56,6 +56,7 @@ export const GAMES: IGame[] = [
         limitedOptions: 1,
         limitedRate: 0.75,
       },
+      conversionRate: 160
     },
   },
   // Genshin Impact
@@ -96,6 +97,7 @@ export const GAMES: IGame[] = [
         softPity: 64,
         softPityIncrement: 0.06,
       },
+      conversionRate: 160
     },
   },
   // Zenless Zone Zero
@@ -135,6 +137,7 @@ export const GAMES: IGame[] = [
         limitedOptions: 1,
         limitedRate: 0.75,
       },
+      conversionRate: 160
     },
   },
 ] as const;
@@ -148,7 +151,7 @@ export const CUSTOM_GAME: IGame = {
     pullName: "Pull",
     pullConjugation: "s",
     currencyName: "Currency",
-    currencyConjugation: "ies",
+    currencyConjugation: "",
     characterName: "Character",
     weaponName: "Weapon",
   },
@@ -175,5 +178,6 @@ export const CUSTOM_GAME: IGame = {
       softPity: 64,
       softPityIncrement: 0.06,
     },
+    conversionRate: 160
   },
 } as const;

--- a/src/lib/games.ts
+++ b/src/lib/games.ts
@@ -4,6 +4,8 @@ export interface IGameTerms {
   limitedCategory: string; //5 star , S tier, 5★
   pullName: string; // e.g. "Wish", "Warp"
   pullConjugation: string; //es , s   (wish-es, warp-s)
+  currencyName: string; // e.g. "Primogem", "Stellar Jade"
+  currencyConjugation: string; // e.g. "s" (Primogem-s, Stellar Jade-s)
   characterName: string; // "Agent", "Character"
   weaponName: string; // "W-Engine", "Light Cone"
 }
@@ -26,6 +28,8 @@ export const GAMES: IGame[] = [
       limitedCategory: "5★",
       pullName: "Warp",
       pullConjugation: "s",
+      currencyName: "Stellar Jade",
+      currencyConjugation: "s",
       characterName: "Character",
       weaponName: "Light Cone",
     },
@@ -63,6 +67,8 @@ export const GAMES: IGame[] = [
       limitedCategory: "5★",
       pullName: "Wish",
       pullConjugation: "es",
+      currencyName: "Primogem",
+      currencyConjugation: "s",
       characterName: "Character",
       weaponName: "Weapon",
     },
@@ -102,6 +108,8 @@ export const GAMES: IGame[] = [
       characterName: "Agent",
       pullName: "Signal Search",
       pullConjugation: "es",
+      currencyName: "Polychrome",
+      currencyConjugation: "s",
       weaponName: "W-Engine",
     },
     simulationSettings: {
@@ -139,6 +147,8 @@ export const CUSTOM_GAME: IGame = {
     limitedCategory: "5★",
     pullName: "Pull",
     pullConjugation: "s",
+    currencyName: "Currenc",
+    currencyConjugation: "ies",
     characterName: "Character",
     weaponName: "Weapon",
   },

--- a/src/lib/simulator.ts
+++ b/src/lib/simulator.ts
@@ -8,6 +8,7 @@ export interface ISimulatorGameSettings {
 
 export interface ISimulatorInput {
   pulls: number;
+  currency: number;
   characterPity: number;
   weaponPity: number;
   isWeaponGuaranteed: boolean;
@@ -52,7 +53,7 @@ export class Simulator {
     let successesfullSimulations = 0;
 
     for (let i = 0; i < input.numSimulations; i++) {
-      let pullsLeft = input.pulls;
+      let pullsLeft = input.pulls + (Math.floor(input.currency / 160));
 
       const charData: ISimulationData = {
         type: "character",

--- a/src/lib/simulator.ts
+++ b/src/lib/simulator.ts
@@ -4,6 +4,8 @@ export interface ISimulatorGameSettings {
 
   weaponRate: IRate;
   weaponPity: IPity;
+
+  conversionRate: number;
 }
 
 export interface ISimulatorInput {
@@ -16,6 +18,7 @@ export interface ISimulatorInput {
   characterCopies: number;
   weaponCopies: number;
   numSimulations: number;
+  conversionRate: number;
 }
 
 interface IRate {
@@ -53,7 +56,7 @@ export class Simulator {
     let successesfullSimulations = 0;
 
     for (let i = 0; i < input.numSimulations; i++) {
-      let pullsLeft = input.pulls + (Math.floor(input.currency / 160));
+      let pullsLeft = input.pulls + (Math.floor(input.currency / this.settings.conversionRate));
 
       const charData: ISimulationData = {
         type: "character",


### PR DESCRIPTION
This pull request introduces two main changes:
1. **Currency Conversion:**  
   Users can now input a numeric currency value, which is automatically converted into pulls based on the respective game:
   - **Genshin Impact:** 160 Primogems = 1 Pull  
   - **Honkai: Star Rail:** 160 Stellar Jades = 1 Pull  
   - **Zenless Zone Zero:** 160 Polychromes = 1 Pull  
   - **Custom setting:** Someone told me "simplicity is gud"

2. **Card Centering:**  
   The addition of the currency conversion feature affected the layout by pushing the cards downward. This update also includes layout adjustments to center the cards both **horizontally** and **vertically** for improved visual alignment.


![](https://i.imgur.com/ozwJZP1.gif)